### PR TITLE
Basic generalized Clebsch-Gordan from mace

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,5 +37,5 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pip install -e .
+          pip install -e ".[test]"
           pytest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,10 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persis-credentials: false
       
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
+
+      - name: Reconfigure git to use HTTP authentication
+        run: >
+          git config --global url."https://github.com/".insteadOf
+          ssh://git@github.com/
 
       - name: Get pip cache dir
         id: pip-cache

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,41 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+jobs:
+  ci:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          python -m pip install --upgrade pip wheel
+          echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+
+      - name: Install dependencies
+        run: |
+          pip install jax jaxlib
+
+      - name: Test with pytest
+        run: |
+          pip install -e .
+          pytest

--- a/macx/tools/cg.py
+++ b/macx/tools/cg.py
@@ -1,23 +1,24 @@
 import mace
-from e3nn_jax import Irreps
+from e3nn_jax import Irreps, Irrep
 from macx.tools import cg
 from mace.tools import cg as mace_cg
 from e3nn import o3
 import jax.numpy as jnp
 
-def U_matrix_real_easymode(
+def U_matrix_real( #easymode
     irreps_in, #: Union[str, o3.Irreps],
     irreps_out, #: Union[str, o3.Irreps],
-    correlation, #: int,
-    normalization, #: str = "component",
+    correlation: int,
+    normalization: str = "component",
     filter_ir_mid=None,
     dtype=None,
 	):
 	irreps_in_o3 = o3.Irreps(str(irreps_in))
 	irreps_out_o3 = o3.Irreps(str(irreps_out))
-	U_matrix_torch = mace_cd.U_matrix_real(irreps_in=irreps_in_o3, irreps_out=irreps_out_o3,
+	U_matrix_torch = mace_cg.U_matrix_real(irreps_in=irreps_in_o3, irreps_out=irreps_out_o3,
 						  correlation=correlation, normalization=normalization,
 						  filter_ir_mid=filter_ir_mid)
-	U_matrix_jax = jnp.array(U_matrix_torch.cpu().detach().numpy(), dype=dtype) 
+	U_matrix_jax = [Irrep(str(U_mat)) if isinstance(U_mat, o3.Irrep) else jnp.array(U_mat.cpu().detach().numpy(), dtype=dtype) for U_mat in U_matrix_torch]
+	return U_matrix_jax
 	
 	

--- a/macx/tools/cg.py
+++ b/macx/tools/cg.py
@@ -1,0 +1,23 @@
+import mace
+from e3nn_jax import Irreps
+from macx.tools import cg
+from mace.tools import cg as mace_cg
+from e3nn import o3
+import jax.numpy as jnp
+
+def U_matrix_real_easymode(
+    irreps_in, #: Union[str, o3.Irreps],
+    irreps_out, #: Union[str, o3.Irreps],
+    correlation, #: int,
+    normalization, #: str = "component",
+    filter_ir_mid=None,
+    dtype=None,
+	):
+	irreps_in_o3 = o3.Irreps(str(irreps_in))
+	irreps_out_o3 = o3.Irreps(str(irreps_out))
+	U_matrix_torch = mace_cd.U_matrix_real(irreps_in=irreps_in_o3, irreps_out=irreps_out_o3,
+						  correlation=correlation, normalization=normalization,
+						  filter_ir_mid=filter_ir_mid)
+	U_matrix_jax = jnp.array(U_matrix_torch.cpu().detach().numpy(), dype=dtype) 
+	
+	

--- a/macx/tools/cg.py
+++ b/macx/tools/cg.py
@@ -5,20 +5,28 @@ from mace.tools import cg as mace_cg
 from e3nn import o3
 import jax.numpy as jnp
 
-def U_matrix_real( #easymode
-    irreps_in, #: Union[str, o3.Irreps],
-    irreps_out, #: Union[str, o3.Irreps],
+
+def U_matrix_real(  # easymode
+    irreps_in,  #: Union[str, o3.Irreps],
+    irreps_out,  #: Union[str, o3.Irreps],
     correlation: int,
     normalization: str = "component",
     filter_ir_mid=None,
     dtype=None,
-	):
-	irreps_in_o3 = o3.Irreps(str(irreps_in))
-	irreps_out_o3 = o3.Irreps(str(irreps_out))
-	U_matrix_torch = mace_cg.U_matrix_real(irreps_in=irreps_in_o3, irreps_out=irreps_out_o3,
-						  correlation=correlation, normalization=normalization,
-						  filter_ir_mid=filter_ir_mid)
-	U_matrix_jax = [Irrep(str(U_mat)) if isinstance(U_mat, o3.Irrep) else jnp.array(U_mat.cpu().detach().numpy(), dtype=dtype) for U_mat in U_matrix_torch]
-	return U_matrix_jax
-	
-	
+):
+    irreps_in_o3 = o3.Irreps(str(irreps_in))
+    irreps_out_o3 = o3.Irreps(str(irreps_out))
+    U_matrix_torch = mace_cg.U_matrix_real(
+        irreps_in=irreps_in_o3,
+        irreps_out=irreps_out_o3,
+        correlation=correlation,
+        normalization=normalization,
+        filter_ir_mid=filter_ir_mid,
+    )
+    U_matrix_jax = [
+        Irrep(str(U_mat))
+        if isinstance(U_mat, o3.Irrep)
+        else jnp.array(U_mat.cpu().detach().numpy(), dtype=dtype)
+        for U_mat in U_matrix_torch
+    ]
+    return U_matrix_jax

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,11 @@ import setuptools
 
 base_requires = [
     'jax>=0.3.23',
-    'e3nn-jax>=0.10.1'
+    'e3nn-jax>=0.10.1',
 ]
 test_requires = [
     'pytest',
+    'mace',
 ]
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 import setuptools
 
 base_requires = [
-    'jax>=0.3.23',
-    'e3nn-jax>=0.10.1',
+    "jax>=0.3.23",
+    "e3nn-jax>=0.10.1",
 ]
 test_requires = [
-    'pytest',
-    'mace @ git+ssh://git@github.com/ACEsuit/mace#egg=mace',
+    "pytest",
+    "mace @ git+ssh://git@github.com/ACEsuit/mace#egg=mace",
 ]
 
 setuptools.setup(
@@ -16,8 +16,8 @@ setuptools.setup(
     author_email="",
     license="ASL",
     install_requires=base_requires,
-    extras_require={'test': test_requires},
+    extras_require={"test": test_requires},
     packages=setuptools.find_packages(),
     url="https://github.com/sirmarcel/macx",
-    python_requires='>=3.8',
+    python_requires=">=3.8",
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ base_requires = [
 ]
 test_requires = [
     'pytest',
-    'mace',
+    'mace @ git+ssh://git@github.com/ACEsuit/mace#egg=mace',
 ]
 
 setuptools.setup(

--- a/tests/test_cg.py
+++ b/tests/test_cg.py
@@ -22,12 +22,16 @@ def test_U_matrix_shape():
 def test_U_matrix_mace_compare():
     irreps_in = Irreps("1x0e + 1x1o + 1x2e")
     irreps_out = Irreps("1x0e + 1x1o")
+    print('initialized irreps jax')
     irreps_in_mace = o3.Irreps("1x0e + 1x1o + 1x2e")
     irreps_out_mace = o3.Irreps("1x0e + 1x1o")
+    print('initialized irreps e3nn')
     u_matrix = cg.U_matrix_real(
         irreps_in=irreps_in, irreps_out=irreps_out, correlation=3
     )[-1]
+    print('initialized matrix jax')
     u_matrix_mace = mace_cg.U_matrix_real(
         irreps_in=irreps_in_mace, irreps_out=irreps_out_mace, correlation=3
     )[-1]
+    print('initialized matrix e3nn')
     assert jnp.allclose(u_matrix, u_matrix_mace.cpu().detach().numpy())

--- a/tests/test_cg.py
+++ b/tests/test_cg.py
@@ -1,0 +1,9 @@
+import macx
+import mace
+
+# TODO test against mace
+
+# TODO can test CG orthogonality relations
+# https://en.wikipedia.org/wiki/Clebsch%E2%80%93Gordan_coefficients
+
+

--- a/tests/test_cg.py
+++ b/tests/test_cg.py
@@ -6,10 +6,9 @@ from mace.tools import cg as mace_cg
 from e3nn import o3
 import jax.numpy as jnp
 
-# TODO test against mace
-
 # TODO can test CG orthogonality relations
 # https://en.wikipedia.org/wiki/Clebsch%E2%80%93Gordan_coefficients
+
 
 def test_U_matrix_shape():
     irreps_in = Irreps("1x0e + 1x1o + 1x2e")
@@ -19,19 +18,20 @@ def test_U_matrix_shape():
     )[-1]
     assert u_matrix.shape == (3, 9, 9, 9, 21)
 
+
 def test_U_matrix_mace_compare():
     irreps_in = Irreps("1x0e + 1x1o + 1x2e")
     irreps_out = Irreps("1x0e + 1x1o")
-    print('initialized irreps jax')
+    print("initialized irreps jax")
     irreps_in_mace = o3.Irreps("1x0e + 1x1o + 1x2e")
     irreps_out_mace = o3.Irreps("1x0e + 1x1o")
-    print('initialized irreps e3nn')
+    print("initialized irreps e3nn")
     u_matrix = cg.U_matrix_real(
         irreps_in=irreps_in, irreps_out=irreps_out, correlation=3
     )[-1]
-    print('initialized matrix jax')
+    print("initialized matrix jax")
     u_matrix_mace = mace_cg.U_matrix_real(
         irreps_in=irreps_in_mace, irreps_out=irreps_out_mace, correlation=3
     )[-1]
-    print('initialized matrix e3nn')
+    print("initialized matrix e3nn")
     assert jnp.allclose(u_matrix, u_matrix_mace.cpu().detach().numpy())

--- a/tests/test_cg.py
+++ b/tests/test_cg.py
@@ -1,9 +1,33 @@
 import macx
 import mace
+from e3nn_jax import Irreps
+from macx.tools import cg
+from mace.tools import cg as mace_cg
+from e3nn import o3
+import jax.numpy as jnp
 
 # TODO test against mace
 
 # TODO can test CG orthogonality relations
 # https://en.wikipedia.org/wiki/Clebsch%E2%80%93Gordan_coefficients
 
+def test_U_matrix_shape():
+    irreps_in = Irreps("1x0e + 1x1o + 1x2e")
+    irreps_out = Irreps("1x0e + 1x1o")
+    u_matrix = cg.U_matrix_real(
+        irreps_in=irreps_in, irreps_out=irreps_out, correlation=3
+    )[-1]
+    assert u_matrix.shape == (3, 9, 9, 9, 21)
 
+def test_U_matrix_mace_compare():
+    irreps_in = Irreps("1x0e + 1x1o + 1x2e")
+    irreps_out = Irreps("1x0e + 1x1o")
+    irreps_in_mace = o3.Irreps("1x0e + 1x1o + 1x2e")
+    irreps_out_mace = o3.Irreps("1x0e + 1x1o")
+    u_matrix = cg.U_matrix_real(
+        irreps_in=irreps_in, irreps_out=irreps_out, correlation=3
+    )[-1]
+    u_matrix_mace = mace_cg.U_matrix_real(
+        irreps_in=irreps_in_mace, irreps_out=irreps_out_mace, correlation=3
+    )[-1]
+    assert jnp.allclose(u_matrix, u_matrix_mace.cpu().detach().numpy())

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,5 +1,6 @@
 import macx
 
+
 def test_preprocessing():
     # TODO add tests
     some_property1 = True


### PR DESCRIPTION
This currently relies on the cg implementation of mace (and thus adds it and pytorch etc as dependencies). This should be useful for initial prototyping and cross-checking, follow-up PRs should replace it by our own implementation if there's time, to not have a dependency on torch