### PR TITLE
Fix symmetric contraction weight loading test

### DIFF
--- a/tests/test_cg.py
+++ b/tests/test_cg.py
@@ -22,16 +22,12 @@ def test_U_matrix_shape():
 def test_U_matrix_mace_compare():
     irreps_in = Irreps("1x0e + 1x1o + 1x2e")
     irreps_out = Irreps("1x0e + 1x1o")
-    print("initialized irreps jax")
     irreps_in_mace = o3.Irreps("1x0e + 1x1o + 1x2e")
     irreps_out_mace = o3.Irreps("1x0e + 1x1o")
-    print("initialized irreps e3nn")
     u_matrix = cg.U_matrix_real(
         irreps_in=irreps_in, irreps_out=irreps_out, correlation=3
     )[-1]
-    print("initialized matrix jax")
     u_matrix_mace = mace_cg.U_matrix_real(
         irreps_in=irreps_in_mace, irreps_out=irreps_out_mace, correlation=3
     )[-1]
-    print("initialized matrix e3nn")
     assert jnp.allclose(u_matrix, u_matrix_mace.cpu().detach().numpy())

--- a/tests/test_symmetric_contraction.py
+++ b/tests/test_symmetric_contraction.py
@@ -34,13 +34,13 @@ def test_symmetric_contraction():
         return SymContr_jax(irreps_in_jax, irreps_out_jax, correlation)(A)
 
     params = {
-        "symmetric_contraction/~/Contraction_1x0e": {
-            "weights_1": sym_con.contractions["1x0e"].weights["1"].detach(),
-            "weights_2": sym_con.contractions["1x0e"].weights["2"].detach(),
+        "symmetric_contraction/~/Contraction_0e": {
+            "weights_1": sym_con.contractions["1x0e"].weights["1"].detach().numpy(),
+            "weights_2": sym_con.contractions["1x0e"].weights["2"].detach().numpy(),
         }
     }
     params = jax.tree_util.tree_map(lambda x: jnp.array(x), params)
-    jax_B = sym_con_jax.apply(params, A_jax)
+    jax_B = sym_con_jax.apply(params, A_jax).squeeze()
 
     assert jnp.isclose(
         jnp.abs(jnp.array(torch_B.detach()) - jax_B).sum(), 0.0, atol=1.0e-5

--- a/tests/test_symmetric_contraction.py
+++ b/tests/test_symmetric_contraction.py
@@ -39,9 +39,7 @@ def test_symmetric_contraction():
             "weights_2": sym_con.contractions["1x0e"].weights["2"].detach().numpy(),
         }
     }
-    params = jax.tree_util.tree_map(lambda x: jnp.array(x), params)
+    params = jax.tree_util.tree_map(jnp.array, params)
     jax_B = sym_con_jax.apply(params, A_jax).squeeze()
 
-    assert jnp.isclose(
-        jnp.abs(jnp.array(torch_B.detach()) - jax_B).sum(), 0.0, atol=1.0e-5
-    )
+    assert jnp.allclose(jnp.array(torch_B.detach()), jax_B, atol=1e-6)


### PR DESCRIPTION
This fixes the test for SymmetricContraction with weights from pytorch version, the issue was parameter naming (and a shape squeeze which might be relevant) 